### PR TITLE
Update for deprecated crypto function calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ db
 deps
 .DS_Store
 eunit.coverage.xml
+.rebar

--- a/src/sharded_eredis_chash.erl
+++ b/src/sharded_eredis_chash.erl
@@ -69,11 +69,11 @@ create_ring(Shards) ->
 
 -spec hash(binary() | list()) -> integer().
 hash(Key) when is_binary(Key) ->
-    <<Hash:160/integer>> = crypto:sha(Key),
+    <<Hash:160/integer>> = crypto:hash(sha, Key),
     Hash;
 hash(Key) when is_atom(Key) ->
-    <<Hash:160/integer>> = crypto:sha(list_to_binary(atom_to_list(Key))),
+    <<Hash:160/integer>> = crypto:hash(sha, list_to_binary(atom_to_list(Key))),
     Hash;
 hash(Key) ->
-    <<Hash:160/integer>> = crypto:sha(list_to_binary(Key)),
+    <<Hash:160/integer>> = crypto:hash(sha, list_to_binary(Key)),
     Hash.


### PR DESCRIPTION
The main purpose of this pull request is to fix the deprecated call to `crypto:sha`, which has been replaced with `crypto:hash`. I'm know this works as far back as release 15. Starting with release 16 I believe the function was removed completely. If not 16, then definitely 17, because using the latest release of Erlang I can't get it to compile using `crypto:sha`.
