### PR TITLE
fix q() and q2() specifications

### DIFF
--- a/src/sharded_eredis.erl
+++ b/src/sharded_eredis.erl
@@ -25,13 +25,12 @@ stop() ->
 
 %% @doc Query the redis server using eredis. Automatically hashes
 %% the key and selects the correct shard
--spec q(Command::iolist()) ->
-    {ok, binary() | [binary()]} | {error, Reason::binary()}.
+-spec q(Command::[any()]) -> {ok, eredis:return_value()} | {error, Reason::binary() | no_connection}.
 q(Command) ->
     q(Command, ?TIMEOUT).
 
--spec q(Command::iolist(), Timeout::integer()) ->
-    {ok, binary() | [binary()]} | {error, Reason::binary()}.
+-spec q(Command::[any()], Timeout::integer()) -> {ok, eredis:return_value()}
+                                                 | {error, Reason::binary() | no_connection}.
 q(Command = [_, Key|_], Timeout) ->
     Node = sharded_eredis_chash:lookup(Key),
     poolboy:transaction(Node, fun(Worker) ->
@@ -58,13 +57,13 @@ transaction(Key, Fun) when is_function(Fun) ->
     poolboy:transaction(Node, F).    
 
 %% @doc q2 is similar to q but allows the user to specify the node
--spec q2(Node::term(), Command::iolist()) ->
-    {ok, binary() | [binary()]} | {error, Reason::binary()}.
+-spec q2(Node::term(), Command::[any()]) -> {ok, eredis:return_value()}
+                                            | {error, Reason::binary() | no_connection}.
 q2(Node, Command) ->
     q2(Node, Command, ?TIMEOUT).
 
--spec q2(Node::term(), Command::iolist(), Timeout::integer()) ->
-    {ok, binary() | [binary()]} | {error, Reason::binary()}.
+-spec q2(Node::term(), Command::[any()], Timeout::integer()) -> {ok, eredis:return_value()}
+                                                                | {error, Reason::binary() | no_connection}.
 q2(Node, Command, Timeout) ->
     poolboy:transaction(Node, fun(Worker) ->
                                       eredis:q(Worker, Command, Timeout)


### PR DESCRIPTION
q() and q2() specs are not matching eredis:q() ones.
This PR fix it
